### PR TITLE
Feature: Implement Pagination for SpaceX Launches

### DIFF
--- a/Packages/Data/SpaceXRestAPI/Sources/SpaceXRestAPI/DTOs/LaunchDTO.swift
+++ b/Packages/Data/SpaceXRestAPI/Sources/SpaceXRestAPI/DTOs/LaunchDTO.swift
@@ -1,0 +1,158 @@
+//
+//  LaunchDTO.swift
+//
+//
+//  Created by Alex Schäfer on 12.02.24.
+//
+
+import Foundation
+
+struct LaunchDTO: Codable {
+    let id: String
+    let flightNumber: Int
+    let name: String
+    let dateUtc: String
+    let dateUnix: TimeInterval
+    let dateLocal: String
+    let datePrecision: DatePrecision
+    let staticFireDateUtc: String?
+    let staticFireDateUnix: TimeInterval?
+    let tdb: Bool
+    let net: Bool
+    let window: Int?
+    let rocket: String?
+    let success: Bool?
+    let failures: [Failure]
+    let upcoming: Bool
+    let details: String?
+    let fairings: Fairings?
+    let crew: [CrewMember]
+    let ships: [String]
+    let capsules: [String]
+    let payloads: [String]
+    let launchpad: String?
+    let cores: [Core]
+    let links: Links
+    let autoUpdate: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case flightNumber = "flight_number"
+        case name
+        case dateUtc = "date_utc"
+        case dateUnix = "date_unix"
+        case dateLocal = "date_local"
+        case datePrecision = "date_precision"
+        case staticFireDateUtc = "static_fire_date_utc"
+        case staticFireDateUnix = "static_fire_date_unix"
+        case tdb
+        case net
+        case window
+        case rocket
+        case success
+        case failures
+        case upcoming
+        case details
+        case fairings
+        case crew
+        case ships
+        case capsules
+        case payloads
+        case launchpad
+        case cores
+        case links
+        case autoUpdate = "auto_update"
+    }
+
+    enum DatePrecision: String, Codable {
+        case half, quarter, year, month, day, hour
+    }
+
+    struct Failure: Codable {
+        let time: Int
+        let altitude: Int?
+        let reason: String
+    }
+
+    struct Fairings: Codable {
+        let reused: Bool?
+        let recoveryAttempt: Bool?
+        let recovered: Bool?
+        let ships: [String]
+
+        enum CodingKeys: String, CodingKey {
+            case reused
+            case recoveryAttempt = "recovery_attempt"
+            case recovered
+            case ships
+        }
+    }
+
+    struct CrewMember: Codable {
+        let crew: String?
+        let role: String
+    }
+
+    struct Core: Codable {
+        let core: String?
+        let flight: Int?
+        let gridfins: Bool?
+        let legs: Bool?
+        let reused: Bool?
+        let landingAttempt: Bool?
+        let landingSuccess: Bool?
+        let landingType: String?
+        let landpad: String?
+
+        enum CodingKeys: String, CodingKey {
+            case core
+            case flight
+            case gridfins
+            case legs
+            case reused
+            case landingAttempt = "landing_attempt"
+            case landingSuccess = "landing_success"
+            case landingType = "landing_type"
+            case landpad
+        }
+    }
+
+    struct Links: Codable {
+        let patch: Patch
+        let reddit: Reddit
+        let flickr: Flickr
+        let presskit: String?
+        let webcast: String?
+        let youtubeId: String?
+        let article: String?
+        let wikipedia: String?
+
+        enum CodingKeys: String, CodingKey {
+            case patch
+            case reddit
+            case flickr
+            case presskit
+            case webcast
+            case youtubeId = "youtube_id"
+            case article
+            case wikipedia
+        }
+
+        struct Patch: Codable {
+            let small: String?
+            let large: String?
+        }
+
+        struct Reddit: Codable {
+            let campaign: String?
+            let launch: String?
+            let media: String?
+            let recovery: String?
+        }
+
+        struct Flickr: Codable {
+            let small: [String]
+            let original: [String]
+        }
+    }
+}

--- a/Packages/Data/SpaceXRestAPI/Sources/SpaceXRestAPI/DTOs/PaginatedResponseWrapper.swift
+++ b/Packages/Data/SpaceXRestAPI/Sources/SpaceXRestAPI/DTOs/PaginatedResponseWrapper.swift
@@ -1,0 +1,22 @@
+//
+//  PaginatedResponseWrapper.swift
+//
+//
+//  Created by Alex Schäfer on 12.02.24.
+//
+
+import Foundation
+
+struct PaginatedResponseWrapper<T: Decodable>: Decodable {
+    let docs: [T]
+    let totalDocs: Int
+    let offset: Int
+    let limit: Int
+    let totalPages: Int
+    let page: Int
+    let pagingCounter: Int
+    let hasPrevPage: Bool
+    let hasNextPage: Bool
+    let prevPage: Int?
+    let nextPage: Int?
+}

--- a/Packages/Data/SpaceXRestAPI/Sources/SpaceXRestAPI/DTOs/RocketDTO.swift
+++ b/Packages/Data/SpaceXRestAPI/Sources/SpaceXRestAPI/DTOs/RocketDTO.swift
@@ -41,101 +41,102 @@ struct RocketDTO: Codable {
         case firstFlight = "first_flight"
         case country, company, wikipedia, description, id
     }
-}
 
-struct Dimension: Codable {
-    let meters: Double?
-    let feet: Double?
-}
-
-struct FirstStage: Codable {
-    let thrustSeaLevel, thrustVacuum: Thrust
-    let reusable: Bool
-    let engines, fuelAmountTons: Double
-    let burnTimeSec: Int?
-
-    enum CodingKeys: String, CodingKey {
-        case thrustSeaLevel = "thrust_sea_level"
-        case thrustVacuum = "thrust_vacuum"
-        case reusable, engines
-        case fuelAmountTons = "fuel_amount_tons"
-        case burnTimeSec = "burn_time_sec"
+    struct Dimension: Codable {
+        let meters: Double?
+        let feet: Double?
     }
-}
 
-struct SecondStage: Codable {
-    let thrust: Thrust
-    let payloads: Payloads
-    let reusable: Bool
-    let engines, fuelAmountTons: Double
-    let burnTimeSec: Int?
+    struct FirstStage: Codable {
+        let thrustSeaLevel, thrustVacuum: Thrust
+        let reusable: Bool
+        let engines, fuelAmountTons: Double
+        let burnTimeSec: Int?
 
-    enum CodingKeys: String, CodingKey {
-        case thrust, payloads, reusable, engines
-        case fuelAmountTons = "fuel_amount_tons"
-        case burnTimeSec = "burn_time_sec"
+        enum CodingKeys: String, CodingKey {
+            case thrustSeaLevel = "thrust_sea_level"
+            case thrustVacuum = "thrust_vacuum"
+            case reusable, engines
+            case fuelAmountTons = "fuel_amount_tons"
+            case burnTimeSec = "burn_time_sec"
+        }
     }
-}
 
-struct Payloads: Codable {
-    let compositeFairing: CompositeFairing
-    let option1: String
+    struct SecondStage: Codable {
+        let thrust: Thrust
+        let payloads: Payloads
+        let reusable: Bool
+        let engines, fuelAmountTons: Double
+        let burnTimeSec: Int?
 
-    enum CodingKeys: String, CodingKey {
-        case compositeFairing = "composite_fairing"
-        case option1 = "option_1"
+        enum CodingKeys: String, CodingKey {
+            case thrust, payloads, reusable, engines
+            case fuelAmountTons = "fuel_amount_tons"
+            case burnTimeSec = "burn_time_sec"
+        }
     }
-}
 
-struct CompositeFairing: Codable {
-    let height, diameter: Dimension
-}
+    struct Payloads: Codable {
+        let compositeFairing: CompositeFairing
+        let option1: String
 
-struct Thrust: Codable {
-    let kN, lbf: Int
-}
-
-struct Mass: Codable {
-    let kg, lb: Double?
-}
-
-struct Engines: Codable {
-    let isp: ISP
-    let thrustSeaLevel, thrustVacuum: Thrust
-    let number: Int
-    let type, version: String
-    let layout: String? // Optional, falls es null sein kann
-    let engineLossMax: Int?
-    let propellant1, propellant2: String
-    let thrustToWeight: Double
-
-    enum CodingKeys: String, CodingKey {
-        case isp
-        case thrustSeaLevel = "thrust_sea_level"
-        case thrustVacuum = "thrust_vacuum"
-        case number, type, version, layout
-        case engineLossMax = "engine_loss_max"
-        case propellant1 = "propellant_1"
-        case propellant2 = "propellant_2"
-        case thrustToWeight = "thrust_to_weight"
+        enum CodingKeys: String, CodingKey {
+            case compositeFairing = "composite_fairing"
+            case option1 = "option_1"
+        }
     }
-}
 
-struct ISP: Codable {
-    let seaLevel, vacuum: Int
-
-    enum CodingKeys: String, CodingKey {
-        case seaLevel = "sea_level"
-        case vacuum
+    struct CompositeFairing: Codable {
+        let height, diameter: Dimension
     }
-}
 
-struct LandingLegs: Codable {
-    let number: Int
-    let material: String?
-}
+    struct Thrust: Codable {
+        let kN, lbf: Int
+    }
 
-struct PayloadWeight: Codable {
-    let id, name: String
-    let kg, lb: Double
+    struct Mass: Codable {
+        let kg, lb: Double?
+    }
+
+    struct Engines: Codable {
+        let isp: ISP
+        let thrustSeaLevel, thrustVacuum: Thrust
+        let number: Int
+        let type, version: String
+        let layout: String? // Optional, falls es null sein kann
+        let engineLossMax: Int?
+        let propellant1, propellant2: String
+        let thrustToWeight: Double
+
+        enum CodingKeys: String, CodingKey {
+            case isp
+            case thrustSeaLevel = "thrust_sea_level"
+            case thrustVacuum = "thrust_vacuum"
+            case number, type, version, layout
+            case engineLossMax = "engine_loss_max"
+            case propellant1 = "propellant_1"
+            case propellant2 = "propellant_2"
+            case thrustToWeight = "thrust_to_weight"
+        }
+    }
+
+    struct ISP: Codable {
+        let seaLevel, vacuum: Int
+
+        enum CodingKeys: String, CodingKey {
+            case seaLevel = "sea_level"
+            case vacuum
+        }
+    }
+
+    struct LandingLegs: Codable {
+        let number: Int
+        let material: String?
+    }
+
+    struct PayloadWeight: Codable {
+        let id, name: String
+        let kg, lb: Double
+    }
+
 }

--- a/Packages/Data/SpaceXRestAPI/Sources/SpaceXRestAPI/Mapping/LaunchDTO+Mapping.swift
+++ b/Packages/Data/SpaceXRestAPI/Sources/SpaceXRestAPI/Mapping/LaunchDTO+Mapping.swift
@@ -1,0 +1,23 @@
+//
+//  LaunchDTO+Mapping.swift
+//
+//
+//  Created by Alex Schäfer on 12.02.24.
+//
+
+import Foundation
+import SpaceXDomain
+
+extension LaunchDTO {
+    func toDomain() -> Launch {
+        let dateFormatter = ISO8601DateFormatter()
+        let date = dateFormatter.date(from: dateLocal) ?? Date()
+
+        return Launch(
+            id: id,
+            details: details ?? "N/A",
+            rocketId: rocket,
+            date: date
+        )
+    }
+}

--- a/Packages/Data/SpaceXRestAPI/Sources/SpaceXRestAPI/Repositories/LaunchesRepository.swift
+++ b/Packages/Data/SpaceXRestAPI/Sources/SpaceXRestAPI/Repositories/LaunchesRepository.swift
@@ -1,0 +1,43 @@
+//
+//  LaunchesRepository.swift
+//
+//
+//  Created by Alex Schäfer on 12.02.24.
+//
+
+import OSLog
+import SpaceXDomain
+import NetworkService
+
+public final class DefaultLaunchesRepository {
+    private let networkService: NetworkServiceProtocol
+    private let logger = Logger()
+
+    public init(networkService: NetworkServiceProtocol) {
+        self.networkService = networkService
+    }
+}
+
+extension DefaultLaunchesRepository: LaunchesRepository {
+    public func fetchLaunches(for rocketId: String, page: Int = 0, limit: Int = 10) async throws -> Paginated<Launch> {
+        logger.info("Fetching launches for rocket ID \(rocketId)")
+
+        do {
+            let paginatedResponse: PaginatedResponseWrapper<LaunchDTO> = try await networkService.requestAsync(SpaceXRestAPIRouter.launchesByRocket(id: rocketId, page: page, limit: limit))
+
+            let launches = paginatedResponse.docs.map { $0.toDomain() }
+
+            return Paginated(
+                items: launches,
+                totalDocs: paginatedResponse.totalDocs,
+                totalPages: paginatedResponse.totalPages,
+                page: paginatedResponse.page,
+                hasNextPage: paginatedResponse.hasNextPage,
+                hasPrevPage: paginatedResponse.hasPrevPage
+            )
+        } catch {
+            logger.error("Failed to fetch launches: \(error.localizedDescription)")
+            throw error
+        }
+    }
+}

--- a/Packages/Data/SpaceXRestAPI/Sources/SpaceXRestAPI/SpaceXRestAPI.swift
+++ b/Packages/Data/SpaceXRestAPI/Sources/SpaceXRestAPI/SpaceXRestAPI.swift
@@ -4,6 +4,7 @@ import NetworkService
 enum SpaceXRestAPIRouter: Routable {    
     case rockets
     case rocket(id: String)
+    case launchesByRocket(id: String, page: Int, limit: Int)
 
     var baseUrl: URL? {
         URL(string: "https://api.spacexdata.com/v4")
@@ -15,17 +16,50 @@ enum SpaceXRestAPIRouter: Routable {
             return "rockets"
         case .rocket(let id):
             return "rocket/\(id)"
+        case .launchesByRocket:
+            return "launches/query"
         }
     }
 
     var httpMethod: String {
         switch self {
+        case .launchesByRocket:
+            return HTTPMethod.post.rawValue
         default:
-            HTTPMethod.get.rawValue
+            return HTTPMethod.get.rawValue
         }
     }
 
     var headers: [String : String] {
         ["Content-Type": "application/json"]
     }
+
+    var body: Encodable? {
+        switch self {
+        case .launchesByRocket(let rocketId, let page, let limit):
+            return LaunchesByRocketBody(
+                rocket: rocketId,
+                options: QueryOptions(page: page, limit: limit)
+            )
+        default:
+            return nil
+        }
+    }
+}
+
+
+// MARK: - Helper Structs
+struct LaunchesByRocketBody: Encodable {
+    let query: [String: String]
+    let options: QueryOptions
+
+    init(rocket: String, options: QueryOptions) {
+        self.query = ["rocket": rocket]
+        self.options = options
+    }
+}
+
+struct QueryOptions: Encodable {
+    let page: Int
+    let limit: Int
 }

--- a/Packages/Domain/SpaceXDomain/Sources/SpaceXDomain/Entities/Launch.swift
+++ b/Packages/Domain/SpaceXDomain/Sources/SpaceXDomain/Entities/Launch.swift
@@ -1,0 +1,24 @@
+//
+//  File.swift
+//  
+//
+//  Created by Alex Schäfer on 12.02.24.
+//
+
+import Foundation
+
+/// Entity `Launch`
+public struct Launch: Identifiable, Equatable {
+    public let id: String
+    public let details: String
+    public let rocketId: String?
+    public let date: Date
+
+    public init(id: String, details: String, rocketId: String?, date: Date) {
+        self.id = id
+        self.details = details
+        self.rocketId = rocketId
+        self.date = date
+    }
+}
+

--- a/Packages/Domain/SpaceXDomain/Sources/SpaceXDomain/Entities/Paginated.swift
+++ b/Packages/Domain/SpaceXDomain/Sources/SpaceXDomain/Entities/Paginated.swift
@@ -1,0 +1,27 @@
+//
+//  Paginated.swift
+//
+//
+//  Created by Alex Schäfer on 12.02.24.
+//
+
+import Foundation
+
+public struct Paginated<T: Identifiable> {
+    public var id: String { "\(page)" }
+    public let items: [T]
+    public let totalDocs: Int
+    public let totalPages: Int
+    public let page: Int
+    public let hasNextPage: Bool
+    public let hasPrevPage: Bool
+
+    public init(items: [T], totalDocs: Int, totalPages: Int, page: Int, hasNextPage: Bool, hasPrevPage: Bool) {
+        self.items = items
+        self.totalDocs = totalDocs
+        self.totalPages = totalPages
+        self.page = page
+        self.hasNextPage = hasNextPage
+        self.hasPrevPage = hasPrevPage
+    }
+}

--- a/Packages/Domain/SpaceXDomain/Sources/SpaceXDomain/Interfaces/LaunchesRepository.swift
+++ b/Packages/Domain/SpaceXDomain/Sources/SpaceXDomain/Interfaces/LaunchesRepository.swift
@@ -1,0 +1,14 @@
+//
+//  LaunchesRepository.swift
+//
+//
+//  Created by Alex Schäfer on 12.02.24.
+//
+
+import Foundation
+
+public protocol LaunchesRepository {
+    /// Fetches an array of `Launch` for a specific rocket.
+    /// - Parameter rocketId: The unique identifier of the rocket.
+    func fetchLaunches(for rocketId: String, page: Int, limit: Int) async throws -> Paginated<Launch>
+}

--- a/Packages/Domain/SpaceXDomain/Sources/SpaceXDomain/UseCases/FetchRocketLaunchesUseCase.swift
+++ b/Packages/Domain/SpaceXDomain/Sources/SpaceXDomain/UseCases/FetchRocketLaunchesUseCase.swift
@@ -1,0 +1,40 @@
+//
+//  FetchRocketLaunchesUseCase.swift
+//
+//
+//  Created by Alex Schäfer on 12.02.24.
+//
+
+import Foundation
+
+// MARK: - FetchRocketsUseCaseError
+public enum FetchRocketLaunchesUseCaseError: Error {
+    case invalid
+    case forward(Error)
+}
+
+// MARK: - FetchRocketLaunchesUseCase Protocol
+public protocol FetchRocketLaunchesUseCase {
+    /// Fetches an array of `Launch` for a specific rocket asynchronously.
+    /// - Parameter rocketId: The unique identifier of the rocket.
+    func execute(rocketId: String) async throws -> Paginated<Launch>
+}
+
+// MARK: - FetchRocketLaunchesUseCase Default Implementation
+public final class DefaultFetchRocketLaunchesUseCase: FetchRocketLaunchesUseCase {
+    private let repository: LaunchesRepository
+
+    public init(repository: LaunchesRepository) {
+        self.repository = repository
+    }
+
+    // TODO: Add page and limit
+    public func execute(rocketId: String) async throws -> Paginated<Launch> {
+        do {
+            let launches = try await repository.fetchLaunches(for: rocketId, page: 0, limit: 10)
+            return launches
+        } catch {
+            throw FetchRocketLaunchesUseCaseError.forward(error)
+        }
+    }
+}

--- a/Packages/Services/NetworkService/Sources/NetworkService/REST/NetworkService.swift
+++ b/Packages/Services/NetworkService/Sources/NetworkService/REST/NetworkService.swift
@@ -119,6 +119,16 @@ private extension NetworkService {
             urlRequest.addValue(header.value, forHTTPHeaderField: header.key)
         }
 
+        if let body = route.body {
+            do {
+                let jsonData = try JSONEncoder().encode(body)
+                urlRequest.httpBody = jsonData
+            } catch {
+                os_log("Encoding failed", type: .error, error.localizedDescription)
+                return nil
+            }
+        }
+
         return urlRequest
     }
 }

--- a/Packages/Services/NetworkService/Sources/NetworkService/REST/NetworkService.swift
+++ b/Packages/Services/NetworkService/Sources/NetworkService/REST/NetworkService.swift
@@ -7,6 +7,7 @@
 
 import Combine
 import Foundation
+import OSLog
 
 public enum HTTPMethod: String {
     case get = "GET"
@@ -19,6 +20,12 @@ public protocol NetworkServiceProtocol {
     /// Performs a network request and returns a publisher emitting the decoded response.
     /// - Parameter route: The `Routable` resource to request.
     func request<T: Decodable>(_ route: Routable) -> AnyPublisher<T, Error>
+
+    /// Performs an asynchronous network request and returns the decoded response.
+    /// - Parameter route: The `Routable` resource to request.
+    /// - Returns: The decoded response of type `T`.
+    /// - Throws: An error if the request fails or the response cannot be decoded.
+    func requestAsync<T: Decodable>(_ route: Routable) async throws -> T
 }
 
 public final class NetworkService: NetworkServiceProtocol {
@@ -42,18 +49,16 @@ public extension NetworkService {
 
         return session.dataTaskPublisher(for: request)
             .subscribe(on: DispatchQueue.global(qos: .background))
-            .handleEvents(receiveOutput: { data, response in
-                // Loggen der Antwort und des Statuscodes
-                if let httpResponse = response as? HTTPURLResponse {
-                    print("Response Status Code: \(httpResponse.statusCode)")
-                    print("Response Headers: \(httpResponse.allHeaderFields)")
-                }
-                print("Response Data: \(String(data: data, encoding: .utf8) ?? "unable to decode data")")
-            }, receiveCompletion: { completion in
-                // Loggen von Fehlern
-                if case .failure(let error) = completion {
-                    print("Network request failed: \(error)")
-                }
+            .handleEvents(
+                receiveOutput: { data, response in
+                    if let httpResponse = response as? HTTPURLResponse {
+                        os_log("Response: %@", type: .debug, httpResponse.debugDescription)
+                    }
+                }, 
+                receiveCompletion: { completion in
+                    if case .failure(let error) = completion {
+                        os_log("Request failed: %@", type: .error, error.localizedDescription)
+                    }
             })
             .tryMap { data, response -> Data in
                 guard let httpResponse = response as? HTTPURLResponse,
@@ -66,12 +71,36 @@ public extension NetworkService {
             .handleEvents(receiveCompletion: { completion in
                 switch completion {
                 case .finished:
-                    print("Decoding successful")
+                    os_log("Decoding successful", type: .info)
                 case .failure(let error):
-                    print("Decoding failed: \(error)")
+                    os_log("Decoding failed", type: .error, error.localizedDescription)
                 }
             })
             .eraseToAnyPublisher()
+    }
+
+    /// Asynchronously fetches data from the network and decodes it to the specified type.
+    func requestAsync<T>(_ route: Routable) async throws -> T where T : Decodable {
+        guard let request = buildRequest(for: route) else {
+            throw NetworkServiceError.invalidURL
+        }
+
+        let (data, response) = try await session.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse,
+              (200...299).contains(httpResponse.statusCode) else {
+            throw NetworkServiceError.requestFailed
+        }
+
+        os_log("Response: %@", type: .debug, httpResponse.debugDescription)
+
+        do {
+            return try JSONDecoder().decode(T.self, from: data)
+        } catch {
+            os_log("Decoding failed", type: .error, error.localizedDescription)
+
+            throw NetworkServiceError.decodingFailed
+        }
     }
 }
 

--- a/Packages/Services/NetworkService/Sources/NetworkService/REST/Routable.swift
+++ b/Packages/Services/NetworkService/Sources/NetworkService/REST/Routable.swift
@@ -12,10 +12,15 @@ public protocol Routable {
     var path: String { get }
     var httpMethod: String { get }
     var headers: [String: String] { get }
+    var body: Encodable? { get }
 }
 
 public extension Routable {
     var absoluteUrl: URL? {
         baseUrl?.appendingPathComponent(path)
+    }
+
+    var body: Encodable? {
+        nil
     }
 }


### PR DESCRIPTION
## Description

This pull request introduces a series of enhancements to the SpaceX API integration, focusing on implementing pagination for fetching rocket launches. The changes include updates to the `SpaceXRestAPIRouter`, `NetworkService`, and `LaunchesRepository`, enabling the handling of paginated data using Swift's modern async/await concurrency features.

## Key Changes

1. **SpaceXRestAPIRouter Update**: Extended to support a new case for the launches query, which includes pagination options. This allows fetching a specific page of launch data with a defined limit on the number of results.

2. **Launches Query Body**: Implemented `LaunchesQueryBody` and `QueryOptions` structs to construct the JSON body required for the POST request to the `/launches/query` endpoint.

3. **NetworkService Enhancement**: Updated to handle asynchronous network requests using the `requestAsync` method. This method is designed to work with Swift's async/await syntax, providing a more streamlined approach to handling network responses.

4. **LaunchesRepository Adaptation**: Modified to fetch paginated launch data. The repository now utilizes the async/await pattern to retrieve and process data from the SpaceX API, converting `LaunchDTO` objects to the domain entity `Launch`.

5. **DTO to Domain Mapping**: Added functionality within the repository to map `LaunchDTO` objects to the `Launch` domain model, ensuring that the data is correctly transformed for use within the application.

## Impact

- **Scalability**: The implementation of a generic paginated response model lays the groundwork for future features that require pagination.